### PR TITLE
Fix failing to start httpd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,7 @@ RUN adduser -u 1000 -DG root default && \
     mkdir output && \
     chmod -R g+rwX .
 USER default
+
+EXPOSE 8080
+
 CMD [ "sh", "start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV LC_ALL C
 WORKDIR /app/
 COPY start.sh conf ./
 RUN apk update && \
-    apk add --no-cache wget ca-certificates graphviz ttf-ubuntu-font-family java-postgresql-jdbc && \
+    apk add --no-cache wget ca-certificates graphviz ttf-ubuntu-font-family java-postgresql-jdbc php5 && \
     mkdir lib && \
     wget -nv -O lib/schemaspy.jar https://github.com/schemaspy/schemaspy/releases/download/v6.0.0-rc2/schemaspy-6.0.0-rc2.jar && \
     wget -nv -O lib/mysql-connector-java.jar http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.42/mysql-connector-java-5.1.42.jar && \

--- a/README.md
+++ b/README.md
@@ -10,22 +10,14 @@ SchemaSpy is available at: https://github.com/schemaspy/schemaspy
 
 See also: https://github.com/bcgov/schemaspy
 
+This repo is a clone from: https://github.com/cywolf/schemaspy-docker/
+
+With a fix in master for httpd failing to start: https://github.com/cywolf/schemaspy-docker/pull/3
+
 ## Sample Docker build command
 
 ```
-docker build -t schemaspy https://github.com/cywolf/schemaspy-docker.git
-```
-
-## Sample MySQL Usage
-
-```
-docker run -ti --rm --name schemaspy \
-	-p 8080:8080 \
-	-e DATABASE_TYPE=mysql \
-	-e DATABASE_HOST=mysql -e DATABASE_NAME=mydatabase \
-	-e DATABASE_USER=root -e DATABASE_PASSWORD=mysecretpassword \
-	--link mysql \
-	schemaspy
+docker build -t quiqupltd/schemaspy https://github.com/quiqupltd/schemaspy-docker.git
 ```
 
 ## Sample Postgres Usage
@@ -34,21 +26,11 @@ docker run -ti --rm --name schemaspy \
 docker run -ti --rm --name schemaspy \
 	-p 8080:8080 \
 	-e DATABASE_TYPE=pgsql \
-	-e DATABASE_HOST=postgres -e DATABASE_NAME=mydatabase \
-	-e DATABASE_USER=postgres -e DATABASE_PASSWORD=mysecretpassword \
+	-e DATABASE_HOST=postgres \
+	-e DATABASE_NAME=mydatabase \
+	-e DATABASE_USER=postgres \
+	-e DATABASE_PASSWORD=mysecretpassword \
 	--link postgres \
-	schemaspy
-```
-
-## Sample SQLite3 Usage
-
-```
-mkdir data && cp mydatabase.sqlite3 data/
-docker run -ti --rm --name schemaspy \
-	-p 8080:8080 \
-	-v "$PWD/data":/app/data \
-	-e DATABASE_TYPE=sqlite \
-	-e DATABASE_NAME=/app/data/mydatabase.sqlite3 \
 	schemaspy
 ```
 
@@ -65,3 +47,11 @@ docker run -ti --rm --name schemaspy \
 
 `DATABASE_USER`, `DATABASE_PASSWORD`: The username and password used to establish
 	the database connection.
+
+
+## Building
+
+We can build this image locally and push to db-graph repo which uses it in deployments :
+
+* `docker build --tag registry.quiqup.com/backend/db-graph:schemaspy .`
+* `docker push registry.quiqup.com/backend/db-graph:schemaspy`

--- a/start.sh
+++ b/start.sh
@@ -71,4 +71,4 @@ fi
 
 # busybox httpd
 echo "Starting webserver on port $SERVER_PORT"
-httpd -f -p $SERVER_PORT -h "$OUTPUT_PATH"
+php5 -S localhost:$SERVER_PORT -t $OUTPUT_PATH

--- a/start.sh
+++ b/start.sh
@@ -69,6 +69,5 @@ if [ ! -f "$OUTPUT_PATH/index.html" ]; then
 	exit 1
 fi
 
-# busybox httpd
 echo "Starting webserver on port $SERVER_PORT"
-php5 -S localhost:$SERVER_PORT -t $OUTPUT_PATH
+php5 -S 0.0.0.0:$SERVER_PORT -t $OUTPUT_PATH


### PR DESCRIPTION
When I attempted to use schemaspy as per the README, it failed to boot with the error:

```
start.sh: line 74: httpd: not found
```

I followed the steps: 
```bash
docker build -t schemaspy https://github.com/cywolf/schemaspy-docker.git

docker run -ti --rm --name schemaspy \
        -p 8080:8080 \
        -e DATABASE_TYPE=pgsql \
        -e DATABASE_HOST=postgres \
        -e DATABASE_NAME=development \
        -e DATABASE_USER=username \
        --link postgres \
        schemaspy
```

To solve this I tried adding apache2 package but did not solve it, so instead opted to run a PHP server instead.

Now outputs this
```
...
INFO  - Started Main in 72.722 seconds (JVM running for 73.271)
Starting webserver on port 8080
PHP 5.6.37 Development Server started at Thu Aug 30 13:41:12 2018
Listening on http://0.0.0.0:8080
Document root is /app/output
Press Ctrl-C to quit.
```

And SchemaSpy is viewable via http://localhost:8080/

Closes #2